### PR TITLE
Run git operations locally

### DIFF
--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -23,7 +23,10 @@ import shutil
 import tempfile
 import urllib.parse
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Union
+import subprocess
+import shlex
+from shlex import quote
 
 from qubesbuilder.common import VerificationMode
 from qubesbuilder.component import QubesComponent
@@ -40,6 +43,10 @@ log = get_logger("fetch")
 
 class FetchError(PluginError):
     pass
+
+
+def quote_list(args: List[Union[str, Path]]) -> str:
+    return " ".join(map(lambda x: quote(str(x)), args))
 
 
 class FetchPlugin(ComponentPlugin):
@@ -224,7 +231,7 @@ class FetchPlugin(ComponentPlugin):
                 ]
             if file.get("uncompress", False):
                 download_cmd += ["--uncompress"]
-            cmd = [" ".join(download_cmd)]
+            cmd = [" ".join(map(shlex.quote, download_cmd))]
             try:
                 executor.run(cmd, copy_in, copy_out, environment=self.environment)
             except ExecutorError as e:
@@ -293,7 +300,7 @@ class FetchPlugin(ComponentPlugin):
                         str(self.component.source_dir / pubkey),
                     ]
 
-            cmd = [" ".join(verify_cmd)]
+            cmd = [" ".join(map(shlex.quote, verify_cmd))]
             try:
                 local_executor.run(cmd, copy_in, copy_out, environment=self.environment)
             except ExecutorError as e:
@@ -332,13 +339,18 @@ class FetchPlugin(ComponentPlugin):
             (source_dir / "vtags", temp_dir),
         ]
         cmd = [
-            f"rm -f {source_dir}/hash {source_dir}/vtags",
-            f"cd {executor.get_builder_dir()}",
+            quote_list(["rm", "-f", "--", source_dir / "hash", source_dir / "vtags"]),
+            quote_list(["cd", "--", executor.get_builder_dir()]),
+            quote_list(["git", "-C", source_dir, "rev-parse", "HEAD^{}"])
+            + " >> "
+            + quote_list([source_dir / "hash"]),
+            quote_list(
+                ["git", "-C", source_dir, "tag", "--points-at", "HEAD", "--list", "v*"]
+            )
+            + " >> "
+            + quote_list([source_dir / "vtags"]),
         ]
-        cmd += [f"git -C {source_dir} rev-parse 'HEAD^{{}}' >> {source_dir}/hash"]
-        cmd += [
-            f"git -C {source_dir} tag --points-at HEAD --list 'v*' >> {source_dir}/vtags"
-        ]
+        log.error(cmd)
         try:
             executor.run(cmd, copy_in, copy_out, environment=self.environment)
         except ExecutorError as e:
@@ -368,19 +380,20 @@ class FetchPlugin(ComponentPlugin):
         # Modules (formerly known as INCLUDED_SOURCES in Makefile.builder)
         modules = parameters.get("modules", [])
         if modules:
-
             # Get git module hashes
             copy_in = [
                 (self.component.source_dir, executor.get_builder_dir()),
             ]
             copy_out = [(source_dir / "modules", temp_dir)]
             cmd = [
-                f"rm -f {source_dir}/modules",
-                f"cd {executor.get_builder_dir()}",
+                quote_list(["rm", "-f", "--", source_dir / "modules"]),
+                quote_list(["cd", "--", source_dir]),
             ]
             for module in modules:
                 cmd += [
-                    f"git -C {source_dir}/{module} rev-parse HEAD >> {source_dir}/modules"
+                    quote_list(["git", "-C", source_dir / module, "rev-parse", "HEAD"])
+                    + " >> "
+                    + quote_list([source_dir / "modules"]),
                 ]
             try:
                 executor.run(cmd, copy_in, copy_out, environment=self.environment)
@@ -424,7 +437,14 @@ class FetchPlugin(ComponentPlugin):
                     ),
                 ]
                 cmd += [
-                    f"{executor.get_plugins_dir()}/fetch/scripts/create-archive {source_dir}/{module['name']} {module['archive']} {module['name']}/",
+                    quote_list(
+                        [
+                            f"{executor.get_plugins_dir()}/fetch/scripts/create-archive",
+                            f"{source_dir}/{module['name']}",
+                            f"{module['archive']}",
+                            f"{module['name']}/",
+                        ]
+                    ),
                 ]
 
             try:


### PR DESCRIPTION
This is needed to ensure that git locking is handled correctly and therefore avoid git repository corruption during local development.